### PR TITLE
#60 - provide jstl dependency

### DIFF
--- a/camel-activemq/pom.xml
+++ b/camel-activemq/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-cxf-jaxrs/pom.xml
+++ b/camel-cxf-jaxrs/pom.xml
@@ -64,7 +64,11 @@
             <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-	    
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
 	</dependencies>
 
     <!-- Build -->

--- a/camel-cxf-jaxws-cdi-xml/pom.xml
+++ b/camel-cxf-jaxws-cdi-xml/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-cxf-jaxws-secure/pom.xml
+++ b/camel-cxf-jaxws-secure/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-cxf-jaxws/pom.xml
+++ b/camel-cxf-jaxws/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-jms-spring/pom.xml
+++ b/camel-jms-spring/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-jms-tx-spring/pom.xml
+++ b/camel-jms-tx-spring/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/camel-jms-tx/pom.xml
+++ b/camel-jms-tx/pom.xml
@@ -80,7 +80,11 @@
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-jms/pom.xml
+++ b/camel-jms/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/camel-mail-spring/pom.xml
+++ b/camel-mail-spring/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/camel-mail/pom.xml
+++ b/camel-mail/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
JSTL is required to have Eclipse resolving dependency on jsp pages. Set
it as provided as Widlfly is providing an implementation.

I used taglibs instead of jstl because it was simply not working in Eclipse, don't know why but as latest wildfly is using taglibs I think that it is is fine.

I provided the property version number in parent pom to avoid repeating it in all children, should I move it inside each children?