### PR TITLE
ENTESB-9222: update quickstarts to use the new bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,11 @@
     <!-- Properties -->
     <properties>
 
+        <!-- configure the Fuse version you want to use here -->
+        <version.fuse>7.0.1.fuse-000008-redhat-4</version.fuse>
+
         <!-- WildFly-Camel versions -->
-        <version.wildfly.camel>5.2.0.fuse-710006</version.wildfly.camel>
+        <version.wildfly.camel>5.2.0.fuse-710012</version.wildfly.camel>
         <version.wildfly>7.1.3.GA-redhat-2</version.wildfly>
 
         <!-- Plugin versions -->
@@ -70,11 +73,10 @@
     <!-- Dependency Management -->
     <dependencyManagement>
         <dependencies>
-            <!-- WildFly Camel -->
             <dependency>
-                <groupId>org.wildfly.camel</groupId>
-                <artifactId>wildfly-camel-bom</artifactId>
-                <version>${version.wildfly.camel}</version>
+                <groupId>org.jboss.redhat-fuse</groupId>
+                <artifactId>fuse-eap-bom</artifactId>
+                <version>${version.fuse}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Now that https://github.com/jboss-fuse/redhat-fuse/pull/12 and https://github.com/jboss-fuse/fuse-jenkins-pipelines/pull/40 have been merged, we can use the fuse BOM also for wildfly-camel examples (rh branch).