### PR TITLE
[ENTESB-9327] camel-cxf-jaxws-cdi-secure does not work with IBM JDK

### DIFF
--- a/camel-cxf-jaxws-cdi-secure/src/main/java/org/wildfly/camel/examples/cxf/jaxws/Application.java
+++ b/camel-cxf-jaxws-cdi-secure/src/main/java/org/wildfly/camel/examples/cxf/jaxws/Application.java
@@ -95,6 +95,7 @@ public class Application {
         sslContextParameters.setClientParameters(sslContextClientParameters);
         sslContextParameters.setKeyManagers(kmp);
         sslContextParameters.setCertAlias("client");
+        sslContextParameters.setSecureSocketProtocol("TLSv1.2");
 
         // so that the client trusts the self-signed server certificate
         final KeyStoreParameters trustStoreParams = new KeyStoreParameters();

--- a/itests/src/main/java/org/wildfly/camel/examples/test/common/SecurityUtils.java
+++ b/itests/src/main/java/org/wildfly/camel/examples/test/common/SecurityUtils.java
@@ -32,6 +32,8 @@ public class SecurityUtils {
             sslcontextBuilder.loadKeyMaterial(keystoreFile.toFile(), pwd, pwd);
         }
 
+        sslcontextBuilder.setProtocol("TLSv1.2");
+
         return new SSLConnectionSocketFactory(sslcontextBuilder.build(), new HostnameVerifier() {
             @Override
             public boolean verify(final String s, final SSLSession sslSession) {


### PR DESCRIPTION
resolves #116