### PR TITLE
[ENTESB-10353] Wildfly-camel-examples - camel-jms, testing page doesn…

### DIFF
--- a/camel-jms-spring/README.md
+++ b/camel-jms-spring/README.md
@@ -40,7 +40,7 @@ To run the example.
 
 3. Build and deploy the project `mvn install -Pdeploy`
 
-4. Browse to http://localhost:8080/example-jms-spring/orders
+4. Browse to http://localhost:8080/example-camel-jms-spring/orders
 
 You should see a page titled 'Orders Received'. As we send orders to the example application, a list
 of orders per country will be listed on this page.

--- a/camel-jms-spring/src/main/webapp/WEB-INF/camel-context.xml
+++ b/camel-jms-spring/src/main/webapp/WEB-INF/camel-context.xml
@@ -84,7 +84,7 @@
                 </when>
                 <otherwise id="whenCountryOther">
                     <log id="logOther" message="Sending order to another country" />
-                    <to id="fileProcessedOther" uri="file:{{jboss.server.data.dir}}/orders/processed/other" />
+                    <to id="fileProcessedOther" uri="file:{{jboss.server.data.dir}}/orders/processed/Other" />
                 </otherwise>
             </choice>
         </route>

--- a/camel-jms/src/main/java/org/wildfly/camel/examples/jms/JmsRouteBuilder.java
+++ b/camel-jms/src/main/java/org/wildfly/camel/examples/jms/JmsRouteBuilder.java
@@ -71,6 +71,6 @@ public class JmsRouteBuilder extends RouteBuilder {
                     .to("file:{{jboss.server.data.dir}}/orders/processed/US")
                 .otherwise()
                     .log("Sending order to another country")
-                    .to("file://{{jboss.server.data.dir}}/orders/processed/other");
+                    .to("file://{{jboss.server.data.dir}}/orders/processed/Other");
     }
 }


### PR DESCRIPTION
…'t show orders from category Other

Issue https://issues.jboss.org/browse/ENTESB-10353

Lower case in route was causing that servlet was unable to read processed orders correctly
missing world in url for camel-jms-spring example, only one occurrence

Other jms examples are correct.