### PR TITLE
ENTESB-9795 Support Running on Java 11/wildfly-camel-examples

### DIFF
--- a/camel-activemq/README.md
+++ b/camel-activemq/README.md
@@ -33,16 +33,16 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
-4. Deploy the ActiveMQ resource adapter `mvn install -Pdeploy-rar`. Note that the resource adapter needs to get
-   configured which is done via CLI script `configure-resource-adapter.cli` invoked by Maven in the next step.
+4. Deploy the ActiveMQ resource adapter `mvn install -Pdeploy-rar`.
 
-5. Build and deploy the project `mvn install -Pdeploy`
+5. Build and deploy the project `mvn install -Pdeploy`. Note that the resource adapter needs to get configured
+   which is done via CLI script `configure-resource-adapter.cli` invoked by Maven in the next step
 
 6. Browse to http://localhost:8080/example-camel-activemq/orders
 
@@ -71,14 +71,5 @@ All processed orders will have been output to:
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
+To undeploy the example run `mvn clean -Pdeploy`.
 
-2. Remove the ActiveMQ resource adapter:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-resource-adapter.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-resource-adapter.cli

--- a/camel-activemq/pom.xml
+++ b/camel-activemq/pom.xml
@@ -201,5 +201,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-cdi/README.md
+++ b/camel-cdi/README.md
@@ -21,11 +21,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-cxf-jaxrs-secure/README.md
+++ b/camel-cxf-jaxrs-secure/README.md
@@ -43,11 +43,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 4. Study `jboss-web-xml` and `web.xml` files in `webapp/WEB-INF` directory of this project. They
 set the application security domain, security roles and constraints.
@@ -71,15 +71,5 @@ The full Camel route can be seen in `src/main/webapp/WEB-INF/cxfrs-camel-context
 
 ## Undeploy
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove the Security Domain using a JBoss CLI script:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-basic-security-rs.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-basic-security-rs.cli
+To undeploy the example run `mvn clean -Pdeploy`.
 

--- a/camel-cxf-jaxrs-secure/pom.xml
+++ b/camel-cxf-jaxrs-secure/pom.xml
@@ -147,5 +147,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-cxf-jaxrs/README.md
+++ b/camel-cxf-jaxrs/README.md
@@ -20,11 +20,11 @@ To run the example.
 
         For Linux:
 
-    ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+    ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
         For Windows:
 
-    %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+    %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-cxf-jaxws-cdi-secure/README.md
+++ b/camel-cxf-jaxws-cdi-secure/README.md
@@ -43,11 +43,11 @@ To run the example
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 4. Copy the security key stores from `src/main/resources/keys` to `${JBOSS_HOME}/standalone/configuration`
 
@@ -95,14 +95,5 @@ endpoint passes the object array to a `cxf:bean` web service producer. The web s
 
 ## Undeploy
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
+To undeploy the example run `mvn clean -Pdeploy`.
 
-2. Unconfigure the example tls security configuration:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-tls-security.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-tls-security.cli

--- a/camel-cxf-jaxws-cdi-secure/pom.xml
+++ b/camel-cxf-jaxws-cdi-secure/pom.xml
@@ -158,5 +158,19 @@
                 <deploy.skip>false</deploy.skip>
             </properties>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.jws</groupId>
+                    <artifactId>jsr181-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-cxf-jaxws-cdi-xml/README.md
+++ b/camel-cxf-jaxws-cdi-xml/README.md
@@ -22,11 +22,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-cxf-jaxws-cdi-xml/pom.xml
+++ b/camel-cxf-jaxws-cdi-xml/pom.xml
@@ -124,5 +124,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.jws</groupId>
+                    <artifactId>jsr181-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-cxf-jaxws-secure/README.md
+++ b/camel-cxf-jaxws-secure/README.md
@@ -43,11 +43,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 4. Study `jboss-web-xml` and `web.xml` files in `webapp/WEB-INF` directory of this project. They
 set the application security domain, security roles and constraints.
@@ -77,14 +77,4 @@ The full Camel route can be seen in `src/main/webapp/WEB-INF/cxfws-security-came
 
 ## Undeploy
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Unconfigure the example tls security configuration:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-basic-security.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-basic-security.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-cxf-jaxws-secure/pom.xml
+++ b/camel-cxf-jaxws-secure/pom.xml
@@ -141,5 +141,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.jws</groupId>
+                    <artifactId>jsr181-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-cxf-jaxws/README.md
+++ b/camel-cxf-jaxws/README.md
@@ -20,11 +20,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-cxf-jaxws/pom.xml
+++ b/camel-cxf-jaxws/pom.xml
@@ -113,5 +113,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.jws</groupId>
+                    <artifactId>jsr181-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-jms-mdb/README.md
+++ b/camel-jms-mdb/README.md
@@ -32,11 +32,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`. Note that this Maven command also invokes the CLI script
    `configure-jms-queues.cli` that creates the JMS queue.
@@ -55,14 +55,4 @@ You should see log entries like the following:
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove JMS queues:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-jms-queues.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-jms-queues.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-jms-mdb/pom.xml
+++ b/camel-jms-mdb/pom.xml
@@ -154,5 +154,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-jms-spring/README.md
+++ b/camel-jms-spring/README.md
@@ -32,11 +32,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`. Note that this Maven command also invokes the CLI script
    `configure-jms-queues.cli` that creates the JMS queue.
@@ -69,14 +69,4 @@ All processed orders will have been output to:
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove JMS queues:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-jms-queues.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-jms-queues.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-jms-tx-spring/README.md
+++ b/camel-jms-tx-spring/README.md
@@ -32,11 +32,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`. Note that this Maven command also invokes the CLI script
    `configure-jms-queues.cli` that creates the JMS queue.
@@ -77,14 +77,4 @@ Note the second line "Order quantity is greater than 10 - rolling back transacti
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove JMS queues:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-jms-queues.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-jms-queues.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-jms-tx-spring/pom.xml
+++ b/camel-jms-tx-spring/pom.xml
@@ -149,5 +149,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-jms-tx/README.md
+++ b/camel-jms-tx/README.md
@@ -32,11 +32,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`. Note that this Maven command also invokes the CLI script
    `configure-jms-queues.cli` that creates the JMS queue.
@@ -77,14 +77,4 @@ Note the second line "Order quantity is greater than 10 - rolling back transacti
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove JMS queues:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-jms-queues.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-jms-queues.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-jms-tx/pom.xml
+++ b/camel-jms-tx/pom.xml
@@ -179,5 +179,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-jms/README.md
+++ b/camel-jms/README.md
@@ -38,11 +38,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`. Note that this Maven command also invokes the CLI script
    `configure-jms-queues.cli` that creates the JMS queue.
@@ -73,14 +73,4 @@ All processed orders will have been output to:
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove JMS queues:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-jms-queues.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-jms-queues.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-jms/pom.xml
+++ b/camel-jms/pom.xml
@@ -164,5 +164,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-jpa-spring/README.md
+++ b/camel-jpa-spring/README.md
@@ -20,11 +20,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-jpa/README.md
+++ b/camel-jpa/README.md
@@ -20,11 +20,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 

--- a/camel-mail-spring/README.md
+++ b/camel-mail-spring/README.md
@@ -69,11 +69,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`
 
@@ -102,14 +102,4 @@ The pop3 endpoint checks for email from the local Greenmail mail server every 30
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove Greenmail socket bindings and mail session:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-mail.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-mail.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-mail-spring/pom.xml
+++ b/camel-mail-spring/pom.xml
@@ -163,5 +163,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-mail/README.md
+++ b/camel-mail/README.md
@@ -63,11 +63,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 3. Build and deploy the project `mvn install -Pdeploy`
 
@@ -96,14 +96,4 @@ The pop3 endpoint checks for email from the local Greenmail mail server every 30
 Undeploy
 --------
 
-1. To undeploy the example run `mvn clean -Pdeploy`.
-
-2. Remove Greenmail socket bindings and mail session:
-
-    For Linux:
-
-        ${JBOSS_HOME}/bin/jboss-cli.sh --connect --file=remove-mail.cli
-
-    For Windows:
-
-        %JBOSS_HOME%\bin\jboss-cli.bat --connect --file=remove-mail.cli
+To undeploy the example run `mvn clean -Pdeploy`.

--- a/camel-mail/pom.xml
+++ b/camel-mail/pom.xml
@@ -178,5 +178,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <!-- dependencies removed from jdk 11 -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/camel-rest-swagger/README.md
+++ b/camel-rest-swagger/README.md
@@ -20,11 +20,11 @@ To run the example.
 
     For Linux:
 
-        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml
+        ${JBOSS_HOME}/bin/standalone.sh -c standalone-full-camel.xml
 
     For Windows:
 
-        %JBOSS_HOME%\bin\standalone.bat -c standalone-full.xml
+        %JBOSS_HOME%\bin\standalone.bat -c standalone-full-camel.xml
 
 2. Build and deploy the project `mvn install -Pdeploy`
 


### PR DESCRIPTION
Issue https://issues.jboss.org/browse/ENTESB-9795

Added profiles allowing to build quickstarts in java 11 and also small changes in README.mds (typically wrong configuration file used in starting server command or removal of unnecessary step from uninstall steps)