### PR TITLE
Revert "Add javax.mail dependency to camel-mail quickstart"

### DIFF
--- a/camel-mail/pom.xml
+++ b/camel-mail/pom.xml
@@ -48,11 +48,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>${version-javax-mail}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <version.wildfly>7.2.1.GA-redhat-00003</version.wildfly>
 
         <!-- Fuse version -->
-        <version.fuse>7.4.0.fuse-740001</version.fuse>
+        <version.fuse>7.4.0.fuse-740020</version.fuse>
 
         <!-- Plugin versions -->
         <version-editorconfig-maven-plugin>0.0.5</version-editorconfig-maven-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <version.wildfly>7.2.1.GA-redhat-00003</version.wildfly>
 
         <!-- Fuse version -->
-        <version.fuse>7.4.0.fuse-740021</version.fuse>
+        <version.fuse>7.4.0.fuse-740001</version.fuse>
 
         <!-- Plugin versions -->
         <version-editorconfig-maven-plugin>0.0.5</version-editorconfig-maven-plugin>
@@ -66,7 +66,6 @@
         <version-maven-surefire-plugin>2.18.1</version-maven-surefire-plugin>
         <version-maven-war-plugin>3.0.0</version-maven-war-plugin>
         <version-wildfly-maven-plugin>2.0.1.Final</version-wildfly-maven-plugin>
-        <version-javax-mail>1.4.7</version-javax-mail>
 
         <deploy.skip>true</deploy.skip>
     </properties>


### PR DESCRIPTION
Revert "Add javax.mail dependency to camel-mail quickstart" - javax.mail shading issue in camel-mail has been fixed

This reverts commit ee3fe8ad142557808be25e61d65e2ac5fb43b969.