### PR TITLE
Remove the mirror profile - cannot go into the productized build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,39 +315,5 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>fuse-mirror</id>
-			<activation>
-				<property>
-					<name>fuseMirror</name>
-				</property>
-			</activation>
-			<repositories>
-				<repository>
-					<id>fuse-mirror</id>
-					<url>http://10.0.144.111:8081/repository/maven-public</url>
-					<releases>
-						<enabled>true</enabled>
-						<checksumPolicy>fail</checksumPolicy>
-					</releases>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>fuse-mirror</id>
-					<url>http://10.0.144.111:8081/repository/maven-public</url>
-					<releases>
-						<enabled>true</enabled>
-						<checksumPolicy>fail</checksumPolicy>
-					</releases>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
Remove the mirror settings, we cannot be adding internal repositories