### PR TITLE
ENTESB-14458 Update groupIds/artifactIds for eap upgrade

### DIFF
--- a/camel-activemq/pom.xml
+++ b/camel-activemq/pom.xml
@@ -52,8 +52,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -63,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-cdi/pom.xml
+++ b/camel-cdi/pom.xml
@@ -43,8 +43,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -54,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-cxf-jaxrs-secure/pom.xml
+++ b/camel-cxf-jaxrs-secure/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-cxf-jaxrs/pom.xml
+++ b/camel-cxf-jaxrs/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-cxf-jaxws-cdi-secure/pom.xml
+++ b/camel-cxf-jaxws-cdi-secure/pom.xml
@@ -53,13 +53,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-cxf-jaxws-cdi-xml/pom.xml
+++ b/camel-cxf-jaxws-cdi-xml/pom.xml
@@ -48,8 +48,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -60,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-cxf-jaxws-secure/pom.xml
+++ b/camel-cxf-jaxws-secure/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-cxf-jaxws/pom.xml
+++ b/camel-cxf-jaxws/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-jms-mdb/pom.xml
+++ b/camel-jms-mdb/pom.xml
@@ -46,8 +46,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -62,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-jms-spring/pom.xml
+++ b/camel-jms-spring/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-jms-tx-spring/pom.xml
+++ b/camel-jms-tx-spring/pom.xml
@@ -41,13 +41,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-jms-tx/pom.xml
+++ b/camel-jms-tx/pom.xml
@@ -36,8 +36,13 @@
 
         <!-- Provided -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -61,8 +66,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -72,12 +77,12 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <artifactId>jboss-transaction-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-jms/pom.xml
+++ b/camel-jms/pom.xml
@@ -46,8 +46,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -62,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/camel-jpa-spring/pom.xml
+++ b/camel-jpa-spring/pom.xml
@@ -48,18 +48,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <artifactId>jboss-transaction-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/camel-jpa/pom.xml
+++ b/camel-jpa/pom.xml
@@ -58,18 +58,23 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -79,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <artifactId>jboss-transaction-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/camel-mail-spring/pom.xml
+++ b/camel-mail-spring/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-mail/pom.xml
+++ b/camel-mail/pom.xml
@@ -48,8 +48,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -65,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/camel-rest-swagger/pom.xml
+++ b/camel-rest-swagger/pom.xml
@@ -53,18 +53,23 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <artifactId>jboss-transaction-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/camel-soap-rest-bridge/src/main/java/io/fabric8/quickstarts/camel/bridge/security/KeycloakRolesClaimsHandler.java
+++ b/camel-soap-rest-bridge/src/main/java/io/fabric8/quickstarts/camel/bridge/security/KeycloakRolesClaimsHandler.java
@@ -18,7 +18,6 @@
  */
 package io.fabric8.quickstarts.camel.bridge.security;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -43,7 +42,7 @@ import org.keycloak.representations.idm.UserRepresentation;
  */
 public class KeycloakRolesClaimsHandler implements ClaimsHandler {
 
-    public static final URI ROLE = URI.create("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role");
+    public static final String ROLE = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
 
     private String address;
     private String realm;
@@ -91,8 +90,8 @@ public class KeycloakRolesClaimsHandler implements ClaimsHandler {
         return null;
     }
 
-    public List<URI> getSupportedClaimTypes() {
-        List<URI> list = new ArrayList<URI>();
+    public List<String> getSupportedClaimTypes() {
+        List<String> list = new ArrayList<String>();
         list.add(ROLE);
         return list;
     }

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -408,6 +408,7 @@
                                         <feature-pack>
                                             <groupId>org.wildfly.camel</groupId>
                                             <artifactId>wildfly-camel-galleon-pack</artifactId>
+					    <version>${version.wildfly.camel}</version>
                                             <inherit-configs>true</inherit-configs>
                                         </feature-pack>
                                     </feature-packs>

--- a/itests/src/main/java/org/wildfly/camel/examples/test/activemq/ActiveMQExampleTest.java
+++ b/itests/src/main/java/org/wildfly/camel/examples/test/activemq/ActiveMQExampleTest.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 import org.wildfly.camel.examples.test.jms.AbstractJMSExampleTest;
 import org.wildfly.camel.test.common.utils.DMRUtils;
+import org.wildfly.camel.test.common.utils.WildFlyCli;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -56,6 +57,7 @@ public class ActiveMQExampleTest extends AbstractJMSExampleTest {
                 .addStep("subsystem=resource-adapters/resource-adapter=amq-ra.rar/admin-objects=OrdersQueue/config-properties=PhysicalName", "add(value=OrdersQueue)")
                 .build();
             managementClient.getControllerClient().execute(batchNode);
+            new WildFlyCli().run("reload").assertSuccess();
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -60,19 +60,20 @@
             http://download-node-02.eng.bos.redhat.com/released/JBoss-middleware/eap7
         	https://maven.repository.redhat.com/ga/org/jboss/eap/jboss-eap-parent
         -->
-        <version.wildfly>7.2.7.GA-redhat-00004</version.wildfly>
+        <version.wildfly>7.3.1.GA-redhat-00003</version.wildfly>
+        <version.wildfly.camel>5.6.0.fuse-780001</version.wildfly.camel>
 
         <!-- Fuse version -->
-        <version.fuse>7.7.0.fuse-770010</version.fuse>
+        <version.fuse>7.8.0.fuse-sb2-780008</version.fuse>
 
         <!-- Other versions -->
         <version.keycloak>10.0.1</version.keycloak>
-        <version.wildfly.cxf>3.2.11.redhat-00001</version.wildfly.cxf>
+        <version.wildfly.cxf>3.3.5.redhat-00001</version.wildfly.cxf>
         
         <!-- Plugin versions -->
         <version-cxf-plugin>${version.wildfly.cxf}</version-cxf-plugin>
         <version-exec-maven-plugin>1.4.0</version-exec-maven-plugin>
-        <version-galleon-maven-plugin>2.0.2.Final</version-galleon-maven-plugin>
+        <version-galleon-maven-plugin>4.2.4.Final</version-galleon-maven-plugin>
         <version-maven-antrun-plugin>1.8</version-maven-antrun-plugin>
         <version-maven-assembly-plugin>2.4</version-maven-assembly-plugin>
         <version-maven-compiler-plugin>3.1</version-maven-compiler-plugin>
@@ -82,11 +83,11 @@
         <version-maven-source-plugin>2.3</version-maven-source-plugin>
         <version-maven-surefire-plugin>2.18.1</version-maven-surefire-plugin>
         <version-maven-war-plugin>3.0.0</version-maven-war-plugin>
-        <version-wildfly-galleon-plugin>2.0.3.Final</version-wildfly-galleon-plugin>
+        <version-wildfly-galleon-plugin>4.2.4.Final</version-wildfly-galleon-plugin>
         <version-wildfly-maven-plugin>2.0.1.Final</version-wildfly-maven-plugin>
 
         <!-- EAP server name -->
-        <jboss.server.name>jboss-eap-7.2</jboss.server.name>
+        <jboss.server.name>jboss-eap-7.3</jboss.server.name>
         
         <deploy.skip>true</deploy.skip>
     </properties>


### PR DESCRIPTION
- Updated groupIds/artifactIds to match the EAP upgrade
- changes to respond to cxf api changes in camel-soap-rest-bridge (see https://github.com/fabric8-quickstarts/spring-boot-camel-soap-rest-bridge/commit/057940a17ac526a52f91df867f6adc27d32b01b8)
- Upgrade to a 7.8 redhat-fuse fuse.version
- Upgrade to galleon-maven-plugin 4.2.4.Final - this required adding a version.wildfly-camel to the pom.xml, which we should try to find a way to remove or workaround