### PR TITLE
Removing cxf-codegen-plugin + updating version

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -273,34 +273,13 @@
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-codegen-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-sources</id>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <wsdlOptions>
-                                <wsdlOption>
-                                    <wsdl>src/main/resources/wsdl/weatherprovider.wsdl</wsdl>
-                                    <faultSerialVersionUID>1</faultSerialVersionUID>
-                                </wsdlOption>
-                            </wsdlOptions>
-                        </configuration>
-                        <goals>
-                            <goal>wsdl2java</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
-    
+
         <!--
-            Provision EAP + Camel Subsystem 
+            Provision EAP + Camel Subsystem
         -->
         <profile>
             <id>installServer</id>
@@ -435,6 +414,6 @@
                 </plugins>
             </build>
         </profile>
-        
+
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
 	<!--
 		This version follows the WildFly-Camel version
-	
+
 		WFC-5.3.0 => 5.3.x
 		WFC-5.4.0 => 5.4.x
 		WFC-6.0.0 => 6.0.x
@@ -62,15 +62,15 @@
             https://download.eng.bos.redhat.com/brewroot/repos/jb-eap-7.3-maven-build/latest/maven/org/jboss/eap/jboss-eap-parent
         -->
         <version.wildfly>7.4.0.CD21-redhat-00001</version.wildfly>
-        <version.wildfly.camel>5.7.0.fuse-790024</version.wildfly.camel>
+        <version.wildfly.camel>5.7.0.fuse-7_10_0-00001</version.wildfly.camel>
 
         <!-- Fuse version -->
-        <version.fuse>7.9.0.fuse-sb2-790033</version.fuse>
+        <version.fuse>7.10.0.fuse-sb2-7_10_0-00001</version.fuse>
 
         <!-- Other versions -->
         <version.keycloak>10.0.1</version.keycloak>
         <version.wildfly.cxf>3.3.7.redhat-00001</version.wildfly.cxf>
-        
+
         <!-- Plugin versions -->
         <version-cxf-plugin>${version.wildfly.cxf}</version-cxf-plugin>
         <version-exec-maven-plugin>1.6.0</version-exec-maven-plugin>
@@ -89,7 +89,7 @@
 
         <!-- EAP server name -->
         <jboss.server.name>jboss-eap-7.4</jboss.server.name>
-        
+
         <deploy.skip>true</deploy.skip>
     </properties>
 
@@ -294,11 +294,11 @@
         </repository>
         <!--
             For stuff that is not yet released ...
-            mvn clean install -s configuration/settings.xml -Pfuse-mirror  
+            mvn clean install -s configuration/settings.xml -Pfuse-mirror
             http://10.0.144.111:8081/repository/maven-public/
         -->
     </repositories>
-    
+
     <pluginRepositories>
         <pluginRepository>
             <id>redhat-ga</id>


### PR DESCRIPTION
Removed cxf-codegen-plugin which is not needed anymore (because of https://github.com/wildfly-extras/wildfly-camel-examples/commit/73e03eb1d94a40cbfb93db836b858737a34388b4) and upgraded versions of dependencies.
These changes should make prod build successful.