### PR TITLE
Update maven-war-plugin to support Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version-maven-resources-plugin>2.7</version-maven-resources-plugin>
         <version-maven-source-plugin>2.3</version-maven-source-plugin>
         <version-maven-surefire-plugin>2.18.1</version-maven-surefire-plugin>
-        <version-maven-war-plugin>3.0.0</version-maven-war-plugin>
+        <version-maven-war-plugin>3.3.2</version-maven-war-plugin>
         <version-wildfly-maven-plugin>2.0.1.Final</version-wildfly-maven-plugin>
 
         <deploy.skip>true</deploy.skip>


### PR DESCRIPTION
We use camel-cdi example in one of our EAP tests and it does not work with Java 17 as it is not possible to compile it. By updating the version of maven-war-plugin to 3.3.2 we can continue to use it with Java 17.